### PR TITLE
Changed param names since they are reserved

### DIFF
--- a/fakecrop/jquery.fakecrop.js
+++ b/fakecrop/jquery.fakecrop.js
@@ -11,8 +11,8 @@
 			return { w : item.width()/settings.wrapperWidth, 
 					h : item.height()/settings.wrapperHeight };
 		},
-		center : function (long, short) {
-			return parseInt((long-short)/2, 10);
+		center : function (longVal, shortVal) {
+			return parseInt((longVal-shortVal)/2, 10);
 		},
 		scaleToFill : function (args) {
 			var item = args.item,


### PR DESCRIPTION
These two parameters used on line14 are reserved words (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words)...changed so that it doesn't cause issues. I encountered this issue when minifying this script using the Google Closure compiler.
